### PR TITLE
Fixed import paths

### DIFF
--- a/applications/dev-client/consumer_menu.go
+++ b/applications/dev-client/consumer_menu.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	devclienttypes "github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	devclienttypes "github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 func mPrepareNewConsumer() error {

--- a/applications/dev-client/general_menu.go
+++ b/applications/dev-client/general_menu.go
@@ -7,12 +7,12 @@ import (
 	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
-	devclienttypes "github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	devclienttypes "github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 func mGetDeviceInfo() error {

--- a/applications/dev-client/main.go
+++ b/applications/dev-client/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var hceCard types.HCECard

--- a/applications/dev-client/menu_system.go
+++ b/applications/dev-client/menu_system.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	devclienttypes "github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
+	devclienttypes "github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
 )
 
 var sdk wpwithin.WPWithin

--- a/applications/dev-client/producer_menu.go
+++ b/applications/dev-client/producer_menu.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	devclienttypes "github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	devclienttypes "github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 func mNewProducer() error {

--- a/applications/dev-client/types/deviceprofile.go
+++ b/applications/dev-client/types/deviceprofile.go
@@ -1,7 +1,7 @@
 package devclienttypes
 
 import (
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 type DeviceProfile struct {

--- a/applications/rpc-agent/main.go
+++ b/applications/rpc-agent/main.go
@@ -8,8 +8,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/rifflock/lfshook"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc"
 )
 
 var applicationVersion string

--- a/examples/device-scanner/main.go
+++ b/examples/device-scanner/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
 )
 
 // Flags

--- a/examples/pi-led/handler.go
+++ b/examples/pi-led/handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stianeikeland/go-rpio"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // Handler handles the events coming from Worldpay Within

--- a/examples/pi-led/main.go
+++ b/examples/pi-led/main.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var wpw wpwithin.WPWithin

--- a/examples/sample-consumer/main.go
+++ b/examples/sample-consumer/main.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var wpw wpwithin.WPWithin

--- a/examples/sample-producer-callbacks/eventhandler.go
+++ b/examples/sample-producer-callbacks/eventhandler.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // EventHandlerImpl Handle events from the SDK Core

--- a/examples/sample-producer-callbacks/main.go
+++ b/examples/sample-producer-callbacks/main.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var wpw wpwithin.WPWithin

--- a/examples/securenet-example/consumer/main.go
+++ b/examples/securenet-example/consumer/main.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/securenet"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/securenet"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var wpw wpwithin.WPWithin

--- a/examples/securenet-example/producer/eventhandler.go
+++ b/examples/securenet-example/producer/eventhandler.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // EventHandlerImpl Handle events from the SDK Core

--- a/examples/securenet-example/producer/main.go
+++ b/examples/securenet-example/producer/main.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/applications/dev-client/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/securenet"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/applications/dev-client/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/securenet"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var wpw wpwithin.WPWithin

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client/client.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client/client.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
 )
 
 // Client enables interaction with the Worldpay API

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client/connectionImpl.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client/connectionImpl.go
@@ -12,10 +12,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/utils"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/utils"
 
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // ConnectionImpl Required details to make a connection to the API server

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent/chargetokenrequest.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent/chargetokenrequest.go
@@ -1,6 +1,6 @@
 package cardnotpresent
 
-import "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
+import "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
 
 // ChargeTokenRequest represents a request to charge a token where the card is not present
 type ChargeTokenRequest struct {

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent/service.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // Service defines functions related card not present transactions

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization/service.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // Service defines Tokenization related functions

--- a/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization/tokenizecardrequest.go
+++ b/vendor/github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization/tokenizecardrequest.go
@@ -1,6 +1,6 @@
 package tokenization
 
-import "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
+import "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
 
 // TokenizeCardRequest represents a request to convert a payment card to a SecureNet token
 type TokenizeCardRequest struct {

--- a/wpwithin/core/core.go
+++ b/wpwithin/core/core.go
@@ -1,12 +1,12 @@
 package core
 
 import (
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/configuration"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/hte"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/servicediscovery"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/configuration"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/hte"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/servicediscovery"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
 )
 
 // Core This acts as a container for dependencies of the SDK

--- a/wpwithin/core/core_test.go
+++ b/wpwithin/core/core_test.go
@@ -3,10 +3,10 @@ package core
 import (
 	"testing"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/hte"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/servicediscovery"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/hte"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/servicediscovery"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 var device types.Device

--- a/wpwithin/core/factory.go
+++ b/wpwithin/core/factory.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/hte"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/securenet"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/servicediscovery"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/hte"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/securenet"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/servicediscovery"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
 )
 
 const (

--- a/wpwithin/core/factory_test.go
+++ b/wpwithin/core/factory_test.go
@@ -4,12 +4,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/hte"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/securenet"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/hte"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/securenet"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
 )
 
 func TestNewSDKFactory(t *testing.T) {

--- a/wpwithin/hte/client.go
+++ b/wpwithin/hte/client.go
@@ -1,7 +1,7 @@
 package hte
 
 import (
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // PortRangeMin Minimum allowed port

--- a/wpwithin/hte/clientimpl.go
+++ b/wpwithin/hte/clientimpl.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/wpwithin/hte/ordermanager.go
+++ b/wpwithin/hte/ordermanager.go
@@ -1,7 +1,7 @@
 package hte
 
 import (
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // OrderManager coordinates during negotitation/payment/delivery flows

--- a/wpwithin/hte/ordermanagerimpl.go
+++ b/wpwithin/hte/ordermanagerimpl.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // OrderManagerImpl Concrete implementation of order manager.. uses an in memory persistence for orders

--- a/wpwithin/hte/servicehandler.go
+++ b/wpwithin/hte/servicehandler.go
@@ -12,10 +12,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
 )
 
 // ServiceHandler Coordinate requests between RPC interface and internal SDK interface

--- a/wpwithin/hte/serviceimpl.go
+++ b/wpwithin/hte/serviceimpl.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // ServiceImpl Concrete Implementation of HTE service

--- a/wpwithin/psp/onlineworldpay/onlineworldpay.go
+++ b/wpwithin/psp/onlineworldpay/onlineworldpay.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay/types"
-	wpwithin_types "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay/types"
+	wpwithin_types "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // OnlineWorldpay implementation of PSP

--- a/wpwithin/psp/psp.go
+++ b/wpwithin/psp/psp.go
@@ -1,7 +1,7 @@
 package psp
 
 import (
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 // Common configuration map keys

--- a/wpwithin/psp/securenet/securenet.go
+++ b/wpwithin/psp/securenet/securenet.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strconv"
 
-	snclient "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
-	sntypes "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
+	snclient "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/client"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
+	sntypes "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
 )
 
 // SecureNet supports processing of payments using the Secure Net service

--- a/wpwithin/rpc/eventsender.go
+++ b/wpwithin/rpc/eventsender.go
@@ -7,12 +7,12 @@ import (
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
 )
 
 // EventSenderImpl implementation of event.Handler. Used to send events over Thrift RPC

--- a/wpwithin/rpc/service.go
+++ b/wpwithin/rpc/service.go
@@ -7,9 +7,9 @@ import (
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
 )
 
 // ServiceImpl impementation of RPC service

--- a/wpwithin/rpc/wpthrift/gen-go/wpthrift/w_p_within-remote/w_p_within-remote.go
+++ b/wpwithin/rpc/wpthrift/gen-go/wpthrift/w_p_within-remote/w_p_within-remote.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
 )
 
 var _ = wpthrift_types.GoUnusedProtection__

--- a/wpwithin/rpc/wpthrift/gen-go/wpthrift/w_p_within_callback-remote/w_p_within_callback-remote.go
+++ b/wpwithin/rpc/wpthrift/gen-go/wpthrift/w_p_within_callback-remote/w_p_within_callback-remote.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
 )
 
 var _ = wpthrift_types.GoUnusedProtection__

--- a/wpwithin/rpc/wpthrift/gen-go/wpthrift/wpwithin-consts.go
+++ b/wpwithin/rpc/wpthrift/gen-go/wpthrift/wpwithin-consts.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/wpwithin/rpc/wpthrift/gen-go/wpthrift/wpwithin.go
+++ b/wpwithin/rpc/wpthrift/gen-go/wpthrift/wpwithin.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/wpwithin/rpc/wpwithinhandler.go
+++ b/wpwithin/rpc/wpwithinhandler.go
@@ -2,11 +2,11 @@ package rpc
 
 import (
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/rpc/wpthrift/gen-go/wpthrift_types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
 )
 
 // WPWithinHandler handle RPC requests

--- a/wpwithin/servicediscovery/broadcaster.go
+++ b/wpwithin/servicediscovery/broadcaster.go
@@ -1,6 +1,6 @@
 package servicediscovery
 
-import "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+import "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 
 // Broadcaster defines functionality to broadcast a devices presence on a network
 type Broadcaster interface {

--- a/wpwithin/servicediscovery/broadcasterimpl.go
+++ b/wpwithin/servicediscovery/broadcasterimpl.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 type broadcasterImpl struct {

--- a/wpwithin/servicediscovery/scanner.go
+++ b/wpwithin/servicediscovery/scanner.go
@@ -1,6 +1,6 @@
 package servicediscovery
 
-import "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+import "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 
 // Scanner defines function for discovering devices on a network
 type Scanner interface {

--- a/wpwithin/servicediscovery/scannerimpl.go
+++ b/wpwithin/servicediscovery/scannerimpl.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 )
 
 type scannerImpl struct {

--- a/wpwithin/types/event/handler.go
+++ b/wpwithin/types/event/handler.go
@@ -1,6 +1,6 @@
 package event
 
-import "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
+import "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
 
 // Handler defines events fired by this SDK
 type Handler interface {

--- a/wpwithin/wpwithin.go
+++ b/wpwithin/wpwithin.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/configuration"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/core"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/hte"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/types/event"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils"
-	"github.com/wptechinnovation/wpw-sdk-go/wpwithin/utils/wslog"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/configuration"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/core"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/hte"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types/event"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils"
+	"github.com/WPTechInnovation/wpw-sdk-go/wpwithin/utils/wslog"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/wpwithin/wpwithin_test.go
+++ b/wpwithin/wpwithin_test.go
@@ -3,11 +3,11 @@ import (
 	"fmt"
 	"testing"
 	//"runtime"
-	wpw "github.com/wptechinnovation/wpw-sdk-go/wpwithin"
-	types "github.com/wptechinnovation/wpw-sdk-go/wpwithin/types"
-	psp "github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp"
-	securenet "github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/securenet"
-	onlineworldpay "github.com/wptechinnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
+	wpw "github.com/WPTechInnovation/wpw-sdk-go/wpwithin"
+	types "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/types"
+	psp "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp"
+	securenet "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/securenet"
+	onlineworldpay "github.com/WPTechInnovation/wpw-sdk-go/wpwithin/psp/onlineworldpay"
 )
 
 // TODO


### PR DESCRIPTION
Previously import paths were
import "github.com/wptechinnovation/..."
while it was in fact
"github.com/WPTechInnovation/..."
and while URL was accepted (hostname is case ignore but URL is not
according to www definition) it caused names collision